### PR TITLE
Bump the version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.1.2 (7 June 2016)
+
+Features:
+
+  - New `MadCart::Store::UnavailableStore` error raised when there is a (possibly) temporary problem with the connection to the Store's API.
+
+Refactor:
+
+  - Removed duplication between the different stores in terms of how responses and connections are handled.
+
+## 0.1.1
+
+Initial release

--- a/lib/mad_cart/version.rb
+++ b/lib/mad_cart/version.rb
@@ -1,3 +1,3 @@
 module MadCart
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
**Why?** So that we can use the updated version in our app, since it can't reference gems on github directly.