### PR TITLE
Relax activesupport dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.5
+  - 2.5.3
 cache:
   - bundler
 script:

--- a/lib/mad_cart/model/base.rb
+++ b/lib/mad_cart/model/base.rb
@@ -14,7 +14,7 @@ module MadCart
           include InheritableAttributes
           attr_accessor :additional_attributes
           inheritable_attributes :required_attrs
-          attr_accessor *exposed_attributes
+          attr_accessor(*exposed_attributes)
         end
       end
 
@@ -54,7 +54,7 @@ module MadCart
       module ClassMethods
         def required_attributes(*args)
           @required_attrs = args.map{|a| a.to_s }
-          attr_accessor *args
+          attr_accessor(*args)
         end
 
         def exposed_attributes

--- a/lib/mad_cart/store/base.rb
+++ b/lib/mad_cart/store/base.rb
@@ -54,12 +54,12 @@ module MadCart
       private :valid_by_path?
 
       def parse_response(&block)
-        response = check_for_errors &block
+        response = check_for_errors(&block)
         empty_body?(response) ? [] : response.body
       end
       private :parse_response
 
-      def check_for_errors(&block)
+      def check_for_errors
         response = yield
 
         case response.status

--- a/lib/mad_cart/store/big_commerce.rb
+++ b/lib/mad_cart/store/big_commerce.rb
@@ -52,16 +52,15 @@ module MadCart
 
       def get_customer_hashes
         result = []
-        loop(:make_customer_request) {|c| result << c }
+        for_each(:make_customer_request) {|c| result << c }
         result
       end
 
-      def loop(source, &block)
-
+      def for_each(source, &block)
         items = send(source, :min_id => 1)
 
-        while true
-          items.each &block
+        loop do
+          items.each(&block)
           break if items.count < 50
           items = send(source, :min_id => items.last['id'] + 1 )
         end

--- a/lib/mad_cart/store/spree.rb
+++ b/lib/mad_cart/store/spree.rb
@@ -30,10 +30,10 @@ module MadCart
         parse_response { connection.get('products.json', params) }
       end
 
-      def get_products(options={})
+      def get_products(_options={})
         product_hashes = []
 
-        loop(:make_product_request, :products) do |r|
+        for_each(:make_product_request, :products) do |r|
           product_hashes << r
         end
 
@@ -64,7 +64,7 @@ module MadCart
       def get_customer_hashes
         orders = []
 
-        loop(:make_order_request, :orders) do |r|
+        for_each(:make_order_request, :orders) do |r|
           orders << {
             order_number: r["number"],
             user_email:   r["email"]
@@ -84,7 +84,7 @@ module MadCart
         end.compact
       end
 
-      def loop(source, items_key, &block)
+      def for_each(source, items_key, &block)
         response    = send(source, { :page => 1 })
         items       = response[items_key.to_s]
         pages_count = response['pages']

--- a/lib/mad_cart/version.rb
+++ b/lib/mad_cart/version.rb
@@ -1,3 +1,3 @@
 module MadCart
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/mad_cart.gemspec
+++ b/mad_cart.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "etsy", "0.2.6"
   spec.add_dependency "money", "~> 6.7"
   spec.add_dependency "monetize", "~> 1.4"
-  spec.add_dependency 'activesupport', "~> 4.2"
+  spec.add_dependency "activesupport", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 describe "configuration" do
-
-  # use a clean instance for each test
-  before(:each) do
-    clear_config
-  end
-
   describe "stores" do
     it "does not require store to be added if credentials are passed to constructor" do
       expect { MadCart::Store::BigCommerce.new({:api_key => 'a_fake_key', :store_url => '/path/to/store', :username => 'bob'}) }.not_to raise_error

--- a/spec/lib/model/base_spec.rb
+++ b/spec/lib/model/base_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 describe MadCart::Store::Base do
 
   before(:each) do
-    clear_config
     Object.send(:remove_const, :MyModel) if Object.const_defined?(:MyModel)
     class MyModel
       include MadCart::Model::Base

--- a/spec/lib/model/customer_spec.rb
+++ b/spec/lib/model/customer_spec.rb
@@ -1,11 +1,6 @@
 require "spec_helper"
 
 describe MadCart::Model::Customer do
-
-  before(:each) do
-    clear_config
-  end
-
   it "returns the default attributes" do
     attrs = {"first_name" => 'Bob', "last_name" => 'Sagat', "email" => 'bob@sagat.com'}
     c = MadCart::Model::Customer.new(attrs)

--- a/spec/lib/model/product_spec.rb
+++ b/spec/lib/model/product_spec.rb
@@ -1,11 +1,6 @@
 require "spec_helper"
 
 describe MadCart::Model::Product do
-
-  before(:each) do
-    clear_config
-  end
-
   it "returns the default attributes" do
     extra_attrs = {"external_id" => 'id', "price" => '12USD',
                    "url" => 'path/to/product', "currency_code" => 'ZAR',

--- a/spec/lib/store/base_spec.rb
+++ b/spec/lib/store/base_spec.rb
@@ -16,7 +16,7 @@ describe MadCart::Store::Base do
       MyStore.class_eval do
         create_connection_with :connection_method
 
-        def connection_method(args={})
+        def connection_method(_args={})
           return TestResult
         end
       end
@@ -26,7 +26,7 @@ describe MadCart::Store::Base do
 
     it "accepts a proc" do
       MyStore.class_eval do
-        create_connection_with Proc.new {|args| TestResult }
+        create_connection_with(Proc.new {|_args| TestResult })
       end
 
       expect(MyStore.new.connection).to eql(TestResult)
@@ -207,7 +207,7 @@ describe MadCart::Store::Base do
           @my_instance_var = args.first[:connection]
         end
 
-        def connect_method(*args)
+        def connect_method(*_args)
           return @my_instance_var
         end
       end
@@ -217,10 +217,10 @@ describe MadCart::Store::Base do
 
     it "accepts a proc" do
       MyStore.class_eval do
-        after_initialize Proc.new {|arg| TestResult.new }
+        after_initialize(Proc.new { |_arg| TestResult.new })
         create_connection_with :connect_method
 
-        def connect_method(*args)
+        def connect_method(*_args)
           return @my_instance_var
         end
       end

--- a/spec/lib/store/etsy_spec.rb
+++ b/spec/lib/store/etsy_spec.rb
@@ -1,9 +1,6 @@
 require "spec_helper"
 
 describe MadCart::Store::Etsy do
-
-  before(:each) { clear_config }
-
   describe "retrieving products" do
     context "the store doesn't exist" do
       let(:invalid_store_name) { 'MadeUpStore' }

--- a/spec/lib/store/etsy_spec.rb
+++ b/spec/lib/store/etsy_spec.rb
@@ -35,7 +35,7 @@ describe MadCart::Store::Etsy do
           expect(first_product.name).not_to be_nil
           expect(first_product.description).not_to be_nil
           expect(first_product.image_url).not_to be_nil
-          expect(first_product.additional_attributes['price']).to eql(BigDecimal.new('2.5'))
+          expect(first_product.additional_attributes['price']).to eql(BigDecimal('2.5'))
         end
       end
 
@@ -52,7 +52,7 @@ describe MadCart::Store::Etsy do
             expect(first_product.name).not_to be_nil
             expect(first_product.description).not_to be_nil
             expect(first_product.image_url).not_to be_nil
-            expect(first_product.additional_attributes['price']).to eql(BigDecimal.new('2.2'))
+            expect(first_product.additional_attributes['price']).to eql(BigDecimal('2.2'))
           end
         end
       end

--- a/spec/lib/store/spree_spec.rb
+++ b/spec/lib/store/spree_spec.rb
@@ -32,7 +32,7 @@ describe MadCart::Store::Spree do
     context "retrieval" do
       context "basic spree installation" do
         it "returns all products" do
-          VCR.use_cassette(spree_cassette, :record => :new_episodes) do
+          VCR.use_cassette(spree_cassette) do
             api = MadCart::Store::Spree.new(valid_credentials)
 
             expect(api.products.size).to eql(58)
@@ -50,7 +50,7 @@ describe MadCart::Store::Spree do
 
       context "alternative spree installation" do
         it "returns all products" do
-          VCR.use_cassette(spree_alternative_cassette, :record => :new_episodes) do
+          VCR.use_cassette(spree_alternative_cassette) do
             api = MadCart::Store::Spree.new(valid_alternative_credentials)
 
             expect(api.products.size).to eql(148)
@@ -78,7 +78,7 @@ describe MadCart::Store::Spree do
     context "count" do
 
       it "returns how many products there are" do
-        VCR.use_cassette(spree_cassette, :record => :new_episodes) do
+        VCR.use_cassette(spree_cassette) do
           api = MadCart::Store::Spree.new(valid_credentials)
           expect(api.products_count).to eql(58)
         end
@@ -92,7 +92,7 @@ describe MadCart::Store::Spree do
     context "retrieval" do
 
       it "returns all customers" do
-        VCR.use_cassette(spree_cassette, :record => :new_episodes) do
+        VCR.use_cassette(spree_cassette) do
           api = MadCart::Store::Spree.new(valid_credentials)
 
           expect(api.customers.size).to be > 0
@@ -112,7 +112,7 @@ describe MadCart::Store::Spree do
 
     describe "validating credentials" do
       it "succeeds if it can get orders.json from Spree" do
-        VCR.use_cassette(spree_cassette, :record => :new_episodes) do
+        VCR.use_cassette(spree_cassette) do
           api = MadCart::Store::Spree.new(valid_credentials)
 
           expect(api).to be_valid

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,11 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.include WebMock::API
+
+  config.after(:each) do
+    # Re-initialize the MadCart::Configuration singleton instance
+    Singleton.__init__(MadCart::Configuration)
+  end
 end
 
 VCR.configure do |c|
@@ -31,11 +36,4 @@ VCR.configure do |c|
   c.hook_into :webmock
   #c.default_cassette_options = { :record => :new_episodes }
   #c.debug_logger = File.open('vcr.log', 'w')
-end
-
-
-# helper methods
-def clear_config
-  # Re-initialize the MadCart::Configuration singleton instance
-  Singleton.__init__(MadCart::Configuration)
 end


### PR DESCRIPTION
* Relax activesupport dependency
* Fix rubocop lint errors
* Remove setting to record new VCR episodes
* Fix randomly failing tests with more robust config reset